### PR TITLE
code_ptr validity in ElfDisassembler::disassembleSectionUsingSymbols

### DIFF
--- a/src/disasm/MCParser.cpp
+++ b/src/disasm/MCParser.cpp
@@ -28,7 +28,8 @@ void MCParser::initialize(cs_arch arch, cs_mode mode,
 }
 
 MCParser::~MCParser() {
-    cs_close(&m_handle);
+    if(valid())
+        cs_close(&m_handle);
 }
 
 void MCParser::reset(cs_arch arch, cs_mode mode) {

--- a/src/disasm/MCParser.h
+++ b/src/disasm/MCParser.h
@@ -61,7 +61,7 @@ public:
     }
 
 private:
-    bool m_valid;
+    bool m_valid = false;
     csh m_handle;
     cs_arch m_arch;
     cs_mode m_mode;


### PR DESCRIPTION
There appear to be some assumptions in ElfDisassembler::disassembleSectionUsingSymbols, and these are:

a) the first .text symbol in the ELF symbol table originates at the same address as the start of the .text section
b) the .text symbols are contiguous throughout the .text section
c) none of the .text symbols have addresses with the least significant bit (indicating THUMB mode)
d) the .text symbols are encoded into the ELF in address order
e) all of the .text symbol addresses are within the address range of the section

(a) through (d) are very possible, if not likely.  (e) is unlikely, but was remedied with an additional three lines of code.

What happens in the existing code is that code_ptr is set to the origin of the .text section.  However, if the first symbol is not the same address as the origin, the calls to the Capstone Engine library pass data from the beginning of the section instead of the address of the symbol.  (There is some code that tries to fix the code_ptr in such a scenario, but it only works if the proceeding data is marked with symbol(s) that are indicated to be data.)

Even if the first symbol is the same address as the origin, if there are discontinuities between the end of one symbol and the beginning of the next, the same sort of misalignment occurs.

The end result is that spedi tries to decode data as instructions, and this doesn't go well.

The second commit addresses a segfault caused by PLTProcedureMap.  It invokes MCParser, but that class's deconstructor assumes its initialize() member function has already been called to open the Captone Engine library.
